### PR TITLE
Serializers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'devise'
 gem 'foundation-rails'
 gem 'json'
-
+gem 'active_model_serializers', '0.8.3'
 
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,8 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    active_model_serializers (0.8.3)
+      activemodel (>= 3.0)
     activejob (4.2.4)
       activesupport (= 4.2.4)
       globalid (>= 0.3.0)
@@ -226,6 +228,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers (= 0.8.3)
   byebug
   capybara
   coffee-rails (~> 4.1.0)

--- a/app/assets/javascripts/timeline.js
+++ b/app/assets/javascripts/timeline.js
@@ -3,11 +3,11 @@ var replaceKeywords = function(keywords) {
   var list = $("#keyword-list");
   for (var i = 0; i < keywords.length; i++) {
     list.append("<li class=\"dream-key\">" + keywords[i].text + "</li>");
-  };
+  }
 }
 
 var changeDream = function(dream) {
-  var keywords = dream.dreams_keywords
+  var keywords = dream.dreams_keywords;
   var dreamTitle = $("#dream-title");
   var dreamText = $("#dream-text");
   dreamTitle.text(dream.title);

--- a/app/assets/javascripts/timeline.js
+++ b/app/assets/javascripts/timeline.js
@@ -3,14 +3,13 @@ var replaceKeywords = function(keywords) {
   var list = $("#keyword-list");
   for (var i = 0; i < keywords.length; i++) {
     list.append("<li class=\"dream-key\">" + keywords[i].text + "</li>");
-  }
+  };
 }
 
 var changeDream = function(dream) {
   var keywords = dream.dreams_keywords
   var dreamTitle = $("#dream-title");
   var dreamText = $("#dream-text");
-  var dreamDate = $("#dream-date")
   dreamTitle.text(dream.title);
   dreamText.text(dream.text);
   replaceKeywords(keywords);

--- a/app/assets/javascripts/timeline.js
+++ b/app/assets/javascripts/timeline.js
@@ -1,31 +1,36 @@
+var replaceKeywords = function(keywords) {
+  $(".dream-key").remove();
+  var list = $("#keyword-list");
+  for (var i = 0; i < keywords.length; i++) {
+    list.append("<li class=\"dream-key\">" + keywords[i].text + "</li>");
+  }
+}
+
 var changeDream = function(dream) {
+  var keywords = dream.dreams_keywords
   var dreamTitle = $("#dream-title");
   var dreamText = $("#dream-text");
-  var dreamKeys = $(".dream-key");
+  var dreamDate = $("#dream-date")
   dreamTitle.text(dream.title);
   dreamText.text(dream.text);
-  // loop through dreamKeys
-  // write method to wipe list and write new lis correctly
+  replaceKeywords(keywords);
 };
 
 $(".details").on("click", function(event) {
-  debugger;
   event.preventDefault();
   if(event.isDefaultPrevented()){
       // default event is prevented
   }else{
       event.returnValue = false;
-      console.log("what")
   }
   var dreamId = this.id;
   $.ajax({
     method: "GET",
-    url: ("/dreams"),
+    url: ("/api/v1/dreams/" + dreamId),
     data: { dream_id: dreamId },
     dataType: "json"
   })
   .done(function(data){
-    var activeDream = data["active_dream"];
-    changeDream(activeDream);
+    changeDream(data.dream);
   });
 });

--- a/app/assets/javascripts/timeline.js
+++ b/app/assets/javascripts/timeline.js
@@ -4,7 +4,7 @@ var replaceKeywords = function(keywords) {
   for (var i = 0; i < keywords.length; i++) {
     list.append("<li class=\"dream-key\">" + keywords[i].text + "</li>");
   }
-}
+};
 
 var changeDream = function(dream) {
   var keywords = dream.dreams_keywords;

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,0 +1,7 @@
+module Api
+  module V1
+    class ApiController < ApplicationController
+      abstract!
+    end
+  end
+end

--- a/app/controllers/api/v1/dreams_controller.rb
+++ b/app/controllers/api/v1/dreams_controller.rb
@@ -1,0 +1,15 @@
+module Api
+  module V1
+    class DreamsController < ApiController
+      def index
+        @dreams = Dream.all
+        render json: @dreams
+      end
+
+      def show
+        @dream = Dream.find(params["id"])
+        render json: @dream
+      end
+    end
+  end
+end

--- a/app/controllers/dreams_controller.rb
+++ b/app/controllers/dreams_controller.rb
@@ -3,13 +3,6 @@ class DreamsController < ApplicationController
   def index
     @dreams = Dream.where(user: current_user).order(:date).reverse_order
     @active_dream = @dreams.first
-    respond_to do |format|
-      format.html {  }
-      format.json do
-        @active_dream = Dream.find(params["dream_id"])
-        render json: { active_dream: @active_dream }
-      end
-    end
   end
 
   def new

--- a/app/serializers/dream_serializer.rb
+++ b/app/serializers/dream_serializer.rb
@@ -2,9 +2,13 @@ class DreamSerializer < ActiveModel::Serializer
   has_many :dreams_keywords
 
   attributes :id, :title, :text, :sentiment,
-             :date, :user, :mixed
+             :date, :user, :mixed, :nice_date
 
   def user
     object.user.email
+  end
+
+  def nice_date
+    object.date.strftime("%m/%d/%Y")
   end
 end

--- a/app/serializers/dream_serializer.rb
+++ b/app/serializers/dream_serializer.rb
@@ -1,0 +1,10 @@
+class DreamSerializer < ActiveModel::Serializer
+  has_many :dreams_keywords
+
+  attributes :id, :title, :text, :sentiment,
+             :date, :user, :mixed
+
+  def user
+    object.user.email
+  end
+end

--- a/app/serializers/dreams_keyword_serializer.rb
+++ b/app/serializers/dreams_keyword_serializer.rb
@@ -1,0 +1,11 @@
+class DreamsKeywordSerializer < ActiveModel::Serializer
+  attributes :text, :sentiment, :relevance, :date
+
+  def text
+    object.keyword.text
+  end
+
+  def date
+    object.dream.date
+  end
+end

--- a/app/views/dreams/index.html.erb
+++ b/app/views/dreams/index.html.erb
@@ -12,7 +12,7 @@
     </div>
     <div class="large-3 columns">
       <h4>Themes</h4>
-      <ul>
+      <ul id="keyword-list">
         <% @active_dream.dreams_keywords.each do |keyword|  %>
           <li class="dream-key">
             <%= keyword.keyword.text %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,58 +4,10 @@ Rails.application.routes.draw do
   resources :dreams, only: [:index, :create, :new, :update, :edit, :destroy]
 
   devise_for :users
-  # The priority is based upon order of creation: first created -> highest priority.
-  # See how all your routes lay out with "rake routes".
 
-  # You can have the root of your site routed with "root"
-  # root 'welcome#index'
-
-  # Example of regular route:
-  #   get 'products/:id' => 'catalog#view'
-
-  # Example of named route that can be invoked with purchase_url(id: product.id)
-  #   get 'products/:id/purchase' => 'catalog#purchase', as: :purchase
-
-  # Example resource route (maps HTTP verbs to controller actions automatically):
-  #   resources :products
-
-  # Example resource route with options:
-  #   resources :products do
-  #     member do
-  #       get 'short'
-  #       post 'toggle'
-  #     end
-  #
-  #     collection do
-  #       get 'sold'
-  #     end
-  #   end
-
-  # Example resource route with sub-resources:
-  #   resources :products do
-  #     resources :comments, :sales
-  #     resource :seller
-  #   end
-
-  # Example resource route with more complex sub-resources:
-  #   resources :products do
-  #     resources :comments
-  #     resources :sales do
-  #       get 'recent', on: :collection
-  #     end
-  #   end
-
-  # Example resource route with concerns:
-  #   concern :toggleable do
-  #     post 'toggle'
-  #   end
-  #   resources :posts, concerns: :toggleable
-  #   resources :photos, concerns: :toggleable
-
-  # Example resource route within a namespace:
-  #   namespace :admin do
-  #     # Directs /admin/products/* to Admin::ProductsController
-  #     # (app/controllers/admin/products_controller.rb)
-  #     resources :products
-  #   end
+  namespace :api do
+    namespace :v1 do
+      resources :dreams, only: [:index, :show]
+    end
+  end
 end


### PR DESCRIPTION
Added API route endpoints and controllers, and support for serializers. A dream serializer and a dreams_keyword serializer have been written for custom JSON formatting. Now it is possible to get a neat summary of dream instance keywords (including the "text" from the main keywords table) in a simple JSON structure.

Current journal page AJAX calls now use these routes instead going to the main dreams controller.
